### PR TITLE
Feat: 적대적 노이즈 실시간 진행률 연동 및 보안 정책 개선

### DIFF
--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/config/SecurityConfig.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/config/SecurityConfig.java
@@ -31,17 +31,21 @@ public class SecurityConfig {
                         session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
+                                "/",
+                                "hello",
                                 "/api/auth/**",
-                                "/api/**",
                                 "/oauth2/**",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
-                                "/**"  // ⚡ 모든 요청을 인증 없이 허용 (임시 설정)
+                                "/progress/**",
+                                "/ws/**"
                         ).permitAll()
-                        .requestMatchers("/api/noise/**",
-                                            "/api/users/**"
+                        .requestMatchers("/api/users/**",
+                                        "/api/noise/**",
+                                        "/api/deepfake/**",
+                                        "/api/watermark/**"
                         ).authenticated()
-                        .anyRequest().permitAll()
+                        .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2
                         .userInfoEndpoint(userInfo -> userInfo

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/config/WebConfig.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/config/WebConfig.java
@@ -1,5 +1,6 @@
 package com.deeptruth.deeptruth.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -7,12 +8,16 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
+    @Value("${CORS_ALLOWED_ORIGINS:http://localhost:5173}")
+    private String allowedOrigins;
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:5173") // 프론트엔드 주소
+                .allowedOrigins(allowedOrigins.split(","))
                 .allowedMethods("*")
                 .allowCredentials(true)
-                .allowedHeaders("*");
+                .allowedHeaders("*")
+                .maxAge(3600);
     }
 }


### PR DESCRIPTION
## 📝 Summary
> 적대적 노이즈 기능에 사용자별 실시간 진행률 연동을 추가하고, WebSocket 통신을 위한 보안 정책을 통합 개선했습니다. 기존 ProgressController와 연동되어 개인별 진행률 전송이 가능해졌습니다.

## 💻 Describe your changes
**1. 적대적 노이즈 기능 개선 및 최적화**
- NoiseController/Service 아키텍처 고도화
- 기존 계층화 구조를 기반으로 성능 최적화
- Service Layer의 Flask API 통신 로직을 더욱 안정적으로 개선
- 에러 핸들링 및 파일 처리 로직 강화로 견고성 향상
- 팀 협업을 위한 코드 일관성 및 가독성 향상

**2. 사용자별 실시간 진행률 연동 기능 추가**
- 기존 ProgressController와 연동
    - NoiseService → Flask 호출 시 loginId 전달로 사용자 식별
    - Flask → ProgressController → WebSocket을 통한 개인별 진행률 전송
    - convertAndSendToUser() 활용하여 보안성 강화 (개인별 타겟팅)
    - DeepfakeService, WatermarkService와 동일한 패턴으로 일관성 유지

**3. WebSocket 실시간 진행률을 위한 보안 및 CORS 설정 개선**
- SecurityConfig 보안 정책 통합 개선
    - WebSocket 엔드포인트(/ws/**, /progress/**) 접근 허용
    - 인증/비인증 API 경로 명확한 분리로 보안 체계 정립
- WebConfig CORS 정책 개선
    - 도메인 하드코딩 → 환경변수 방식으로 배포 친화적 변경
    - 성능 최적화 및 운영 환경별 유연한 설정 가능

## #️⃣ Issue number and link
> #89 

## 💬 Message to the Reviewer
> SecurityConfig에서 WebSocket 엔드포인트(`/ws/**`, `/progress/**`) 허용하고, WebConfig에서 CORS를 환경변수(`cors.allowed-origins`) 방식으로 변경했습니다. 
혹시 기존 인증이나 CORS 관련해서 문제 있으면 알려주세요!

