### PR TITLE
Feat: ALB 헬스체크를 위한 Spring Boot Actuator 설정

### DIFF
--- a/deeptruth/build.gradle
+++ b/deeptruth/build.gradle
@@ -52,6 +52,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'com.fasterxml.jackson.core:jackson-databind'
 	implementation 'org.springframework.boot:spring-boot-starter'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/config/SecurityConfig.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/config/SecurityConfig.java
@@ -32,18 +32,20 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/",
-                                "hello",
+                                "/hello",
                                 "/api/auth/**",
                                 "/oauth2/**",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/progress/**",
-                                "/ws/**"
+                                "/ws/**",
+                                "/actuator/health"
                         ).permitAll()
                         .requestMatchers("/api/users/**",
                                         "/api/noise/**",
                                         "/api/deepfake/**",
-                                        "/api/watermark/**"
+                                        "/api/watermark/**",
+                                        "/actuator/**"
                         ).authenticated()
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## 📝 Summary
> ALB 대상 그룹의 헬스체크를 위한 Spring Boot Actuator를 설정하여 서비스 안정성을 개선하였습니다.

## 💻 Describe your changes
- build.gradle에 Spring Boot Actuator 의존성 추가
- application.yml에 헬스체크 엔드포인트 보안 설정
- /actuator/health 경로만 외부 접근 허용하도록 구성
- 기존 Spring Security 설정과 연동하여 보안 강화

## #️⃣ Issue number and link
> #118 

## 💬 Message to the Reviewer
> 기존 OAuth/JWT 인증 시스템은 그대로 유지되며, 헬스체크만 예외 처리됩니다~
