### PR TITLE
Refactor: SecurityConfig에 CORS 설정 연동 추가

### DIFF
--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/config/SecurityConfig.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.deeptruth.deeptruth.service.CustomUserDetailsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -25,6 +26,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
+                .cors(Customizer.withDefaults())
                 .userDetailsService(customUserDetailsService)
                 // 세션 정책: OAuth2는 세션 사용, JWT API는 Stateless
                 .sessionManagement(session ->


### PR DESCRIPTION
## 📝 Summary
> Spring Security에서 CORS 설정을 인식하도록 수정하여 프론트엔드와 백엔드 간 API 통신 시 발생하는 CORS preflight 오류를 해결합니다.

## 💻 Describe your changes
- Spring Security가 WebConfig에 정의된 CORS 설정을 자동으로 적용하도록 연동
- preflight 요청(OPTIONS)이 인증 없이 처리되도록 허용

## #️⃣ Issue number and link
> #114  #118 

## 💬 Message to the Reviewer
> Spring Security가 CORS를 인식하지 못해 발생한 preflight 리다이렉트 오류를 수정했습니다.
