### PR TITLE
Feat: 웹소켓 convertAndSendToUser 사용자 식별을 위한 HttpSessionHandshakeInterce…

### DIFF
--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/config/WebSocketConfig.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/config/WebSocketConfig.java
@@ -31,6 +31,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws")
                 .setAllowedOrigins(frontendUrl, backendUrl)
+                .addInterceptors(httpSessionHandshakeInterceptor())
                 .withSockJS();
     }
 

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/config/WebSocketConfig.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/config/WebSocketConfig.java
@@ -1,11 +1,15 @@
 package com.deeptruth.deeptruth.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import org.springframework.web.socket.server.support.HttpSessionHandshakeInterceptor;
 
 @Configuration
 @EnableWebSocketMessageBroker
@@ -18,8 +22,9 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
-        config.enableSimpleBroker("/topic");
+        config.enableSimpleBroker("/topic","/queue");
         config.setApplicationDestinationPrefixes("/app");
+        config.setUserDestinationPrefix("/user");
     }
 
     @Override
@@ -27,5 +32,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         registry.addEndpoint("/ws")
                 .setAllowedOrigins(frontendUrl, backendUrl)
                 .withSockJS();
+    }
+
+    @Bean
+    public HttpSessionHandshakeInterceptor httpSessionHandshakeInterceptor() {
+        return new HttpSessionHandshakeInterceptor();
     }
 }


### PR DESCRIPTION
## 📝 Summary
 HttpSessionHandshakeInterceptor를 등록하여, 웹소켓 연결(핸드셰이크) 시점에 HTTP 세션에 저장된 Principal (인증 정보)을 웹소켓 세션으로 복사하도록 설정합니다.

## 💻 Describe your changes
```java
// WebSocketConfig.java
@Configuration
@EnableWebSocketMessageBroker
public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {

    // ... (기존 configureMessageBroker 및 기타 메서드 유지)

    @Override
    public void registerStompEndpoints(StompEndpointRegistry registry) {
        registry.addEndpoint("/ws")
                .setAllowedOriginPatterns("*")
                //  HttpSessionHandshakeInterceptor를 등록하여 Principal 정보를 웹소켓 세션으로 전달
                .addInterceptors(httpSessionHandshakeInterceptor()) 
                .withSockJS();
    }
    
    // HttpSessionHandshakeInterceptor 빈 등록
    @Bean
    public HttpSessionHandshakeInterceptor httpSessionHandshakeInterceptor() {
        return new HttpSessionHandshakeInterceptor();
    }
}
```
## #️⃣ Issue number and link
#58 

## 💬 Message to the Reviewer
토큰 기반 인증 시 클라이언트 측 추가 코드가 필요합니다. 아래 예시입니다.
```
// 웹소켓 연결 시 Authorization 헤더에 JWT 포함
let headers = {
    'Authorization': 'Bearer ' + accessToken
};

stompClient.connect(headers, function(frame) {
    // 연결 성공 후 구독 시작
    stompClient.subscribe('/user/topic/progress/' + taskId, function(message) {
        // ...
    });
});
```
