### PR TITLE
Fix: 웹소켓 전송 경로 변경

### DIFF
--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/ProgressController.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/ProgressController.java
@@ -30,7 +30,7 @@ public class ProgressController {
 
         messagingTemplate.convertAndSendToUser(
                 loginId,
-                "/topic/progress/" + progressDto.getTaskId(),
+                "/queue/progress/" + progressDto.getTaskId(),
                 progressDto
         );
         log.info("progress:{}",progressDto.getProgress());


### PR DESCRIPTION
## 📝 Summary
- convertAndSendToUser()를 사용하기위해 전송 경로를 /topic에서 /queue 계열 경로로 변했습니다. 

## 💻 Describe your changes
`convertAndSendToUser()`
- 이 메서드는 Spring의 UserDestinationMessageHandler가 작동해서,
지정한 사용자(Principal 이름)에 연결된 세션에만 메시지를 라우팅합니다. 

| 구독 경로 유형         | 실제 브로커 타입                                       | 메시지 라우팅                          |
| ---------------- | ----------------------------------------------- | -------------------------------- |
| `/topic/**`      | Simple Broker의 “topic” 교환                       | 모든 구독자에게 복제 전송                   |
| `/queue/**`      | Simple Broker의 “queue” 교환                       | 특정 user session 에만 전송            |
| `/user/queue/**` | User Destination Resolver가 로그인 사용자 Principal 매핑 | `convertAndSendToUser()`가 자동 라우팅 |

따라서 ProgressController를 다음과 같이 변경했습니다.

```java
    @PostMapping
    public ResponseEntity<Void> receiveProgress(@RequestBody ProgressDTO progressDto) {

        String loginId = progressDto.getLoginId();

        messagingTemplate.convertAndSendToUser(
                loginId,
                "/queue/progress/" + progressDto.getTaskId(),
                progressDto
        );
        log.info("progress:{}",progressDto.getProgress());
        return ResponseEntity.ok().build();
    }
```

## #️⃣ Issue number and link
#58 

## 💬 Message to the Reviewer
프론트에서는 이렇게 구독해야 정상적으로 받습니다
```
stompClient.subscribe("/user/queue/tasks/" + taskId, (msg) => {
  console.log("진행률:", msg.body);
});
```