### PR TITLE
Feat:RabbitMQ 기반 비동기 딥페이크 탐지 파이프라인 도입 (Spring ↔ RabbitMQ ↔ Flask ↔ S3 ↔ WebSocket)

### DIFF
--- a/deeptruth/build.gradle
+++ b/deeptruth/build.gradle
@@ -55,6 +55,9 @@ dependencies {
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+
+	implementation 'org.springframework.boot:spring-boot-starter-amqp'     // ★ RabbitMQ
+
 }
 
 tasks.named('test') {

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/DeeptruthApplication.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/DeeptruthApplication.java
@@ -2,10 +2,12 @@ package com.deeptruth.deeptruth;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableAsync
 public class DeeptruthApplication {
 
 	public static void main(String[] args) {

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/websocket/DeepfakeRequestMessage.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/websocket/DeepfakeRequestMessage.java
@@ -1,0 +1,34 @@
+package com.deeptruth.deeptruth.base.dto.websocket;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DeepfakeRequestMessage {
+    private String taskId;
+    private Long userId;
+    private String loginId;
+
+    // 경로 A
+    private byte[] fileBytes;
+    private String originalFilename;
+    private String contentType;
+    private long fileSize;
+
+    // 경로 B
+    private String s3Key;
+
+    // 옵션
+    private String mode;
+    private String detector;
+    private String useTta;
+    private String useIllum;
+    private String minFace;
+    private String sampleCount;
+    private String smoothWindow;
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/websocket/TaskAcceptedDTO.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/websocket/TaskAcceptedDTO.java
@@ -1,0 +1,8 @@
+package com.deeptruth.deeptruth.base.dto.websocket;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data @AllArgsConstructor
+public class TaskAcceptedDTO {
+    private String taskId;
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/websocket/TaskEvent.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/base/dto/websocket/TaskEvent.java
@@ -1,0 +1,21 @@
+package com.deeptruth.deeptruth.base.dto.websocket;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TaskEvent<T> {
+    private String type;
+    private String taskId;
+    private Integer progress;
+    private T payload;
+
+    public static TaskEvent<Void> progress(String id, int p) { return TaskEvent.<Void>builder().type("PROGRESS").taskId(id).progress(p).build(); }
+    public static <T> TaskEvent<T> done(String id, T payload) { return TaskEvent.<T>builder().type("DONE").taskId(id).progress(100).payload(payload).build(); }
+    public static TaskEvent<String> error(String id, String code) { return TaskEvent.<String>builder().type("ERROR").taskId(id).payload(code).build(); }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/config/RabbitConfig.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/config/RabbitConfig.java
@@ -1,0 +1,70 @@
+package com.deeptruth.deeptruth.config;
+
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.QueueBuilder;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitConfig {
+
+    public static final String EXCHANGE = "deeptruth.direct";
+    public static final String REQ_QUEUE = "deepfake.request.q";
+    public static final String RES_QUEUE = "deepfake.result.q";
+    public static final String REQ_ROUTING = "deepfake.request";
+    public static final String RES_ROUTING = "deepfake.result";
+
+    private static final String DLX = "deeptruth.dlx";
+    private static final String DLQ = "deepfake.request.dlq";
+
+    @Bean
+    DirectExchange deeptruthExchange() { return new DirectExchange(EXCHANGE, true, false); }
+
+    @Bean
+    DirectExchange dlx() { return new DirectExchange(DLX, true, false); }
+
+    @Bean
+    public Queue requestQueue() {
+        return QueueBuilder.durable(REQ_QUEUE)
+                .withArgument("x-dead-letter-exchange", DLX)
+                .withArgument("x-dead-letter-routing-key", "deepfake.request.dlq")
+                .withArgument("x-message-ttl", 600_000) // 10분 처리 제한
+                .build();
+    }
+
+    @Bean
+    public Queue resultQueue() {
+        return QueueBuilder.durable(RES_QUEUE).build();
+    }
+
+    @Bean
+    public Queue deadLetterQueue() { return QueueBuilder.durable(DLQ).build(); }
+
+    @Bean
+    public Binding bindReq() { return BindingBuilder.bind(requestQueue()).to(deeptruthExchange()).with(REQ_ROUTING); }
+
+    @Bean
+    public Binding bindRes() { return BindingBuilder.bind(resultQueue()).to(deeptruthExchange()).with(RES_ROUTING); }
+
+    @Bean
+    public Binding bindDlq() { return BindingBuilder.bind(deadLetterQueue()).to(dlx()).with("deepfake.request.dlq"); }
+
+    @Bean
+    public MessageConverter jacksonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+
+    @Bean
+    public RabbitTemplate rabbitTemplate(ConnectionFactory cf, MessageConverter mc) {
+        RabbitTemplate rt = new RabbitTemplate(cf);
+        rt.setMessageConverter(mc);
+        return rt;
+    }
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/config/WebSocketConfig.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/config/WebSocketConfig.java
@@ -11,7 +11,8 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
-        config.enableSimpleBroker("/topic");
+        config.enableSimpleBroker("/topic", "/queue");
+        config.setUserDestinationPrefix("/user");
         config.setApplicationDestinationPrefixes("/app");
     }
 

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/DeepfakeDetectionController.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/controller/DeepfakeDetectionController.java
@@ -3,6 +3,7 @@ package com.deeptruth.deeptruth.controller;
 import com.deeptruth.deeptruth.base.dto.deepfake.DeepfakeDetectionDTO;
 import com.deeptruth.deeptruth.base.dto.deepfake.DeepfakeDetectionListDTO;
 import com.deeptruth.deeptruth.base.dto.response.ResponseDTO;
+import com.deeptruth.deeptruth.base.dto.websocket.TaskAcceptedDTO;
 import com.deeptruth.deeptruth.config.CustomUserDetails;
 import com.deeptruth.deeptruth.service.DeepfakeDetectionService;
 import lombok.RequiredArgsConstructor;
@@ -31,8 +32,10 @@ public class DeepfakeDetectionController {
             @RequestPart("file")MultipartFile multipartFile,
             @RequestParam(required = false) Map<String, String> params){
             Map<String, String> form = (params == null) ? new HashMap<>() : params;
-            DeepfakeDetectionDTO dto = deepfakeDetectionService.createDetection(userDetails.getUserId(), multipartFile, form);
-            return ResponseEntity.ok(ResponseDTO.success(200, "딥페이크 탐지 결과 수신 성공", dto));
+            TaskAcceptedDTO accepted =
+                deepfakeDetectionService.createDetectionAsync(userDetails.getUserId(), multipartFile, form);
+
+        return ResponseEntity.accepted().body(ResponseDTO.success(202, "작업 접수됨", accepted));
     }
 
     @GetMapping

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/service/AmazonS3Service.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/service/AmazonS3Service.java
@@ -140,5 +140,21 @@ public class AmazonS3Service {
         }
     }
 
+    public String uploadBinary(InputStream in, String key, String contentType) {
+        try {
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentType(contentType != null ? contentType : "application/octet-stream");
+
+            amazonS3Client.putObject(new PutObjectRequest(bucketName, key, in, metadata));
+
+            return amazonS3Client.getUrl(bucketName, key).toString();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to upload binary to S3", e);
+        }
+    }
+
+    public InputStream openStream(String key) {
+        return amazonS3Client.getObject(bucketName, key).getObjectContent();
+    }
 
 }

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/service/DeepfakeDetectionService.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/service/DeepfakeDetectionService.java
@@ -1,29 +1,28 @@
 package com.deeptruth.deeptruth.service;
 
-import com.deeptruth.deeptruth.base.Enum.DeepfakeDetector;
-import com.deeptruth.deeptruth.base.Enum.DeepfakeMode;
+import com.deeptruth.deeptruth.base.dto.websocket.DeepfakeRequestMessage;
 import com.deeptruth.deeptruth.base.dto.deepfake.BulletDTO;
 import com.deeptruth.deeptruth.base.dto.deepfake.DeepfakeDetectionDTO;
 import com.deeptruth.deeptruth.base.dto.deepfake.DeepfakeDetectionListDTO;
-import com.deeptruth.deeptruth.base.dto.deepfake.FlaskResponseDTO;
+import com.deeptruth.deeptruth.base.dto.websocket.TaskAcceptedDTO;
 import com.deeptruth.deeptruth.base.exception.*;
+import com.deeptruth.deeptruth.config.RabbitConfig;
 import com.deeptruth.deeptruth.entity.DeepfakeDetection;
 import com.deeptruth.deeptruth.entity.User;
 import com.deeptruth.deeptruth.repository.DeepfakeDetectionRepository;
 import com.deeptruth.deeptruth.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
-import org.springframework.http.client.MultipartBodyBuilder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
 
@@ -36,91 +35,75 @@ public class DeepfakeDetectionService {
     private final UserRepository userRepository;
     private final AmazonS3Service amazonS3Service;
     private final DeepfakeViewAssembler assembler;
-    private final ActiveTaskService activeTaskService;
     private final WebClient webClient;
-    @Value("${flask.deepfakeServer.url}")
-    private String flaskServerUrl;
 
-    public DeepfakeDetectionDTO createDetection(Long userId,
-                                                MultipartFile file,
-                                                Map<String, String> form){
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserNotFoundException(userId));
+    private final ActiveTaskService activeTaskService;
+    private final RabbitTemplate rabbitTemplate;
+
+
+    @org.springframework.beans.factory.annotation.Value("${app.upload.prefix:uploads/deepfake}")
+    private String uploadPrefix;
+
+    public TaskAcceptedDTO createDetectionAsync(Long userId, MultipartFile file, Map<String,String> form) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException(userId));
         if (file == null || file.isEmpty()) throw new FileEmptyException();
 
-        String contentType = file.getContentType();
-        if (contentType == null) contentType = MediaType.APPLICATION_OCTET_STREAM_VALUE;
-
-        if (!(contentType.startsWith("image/") || contentType.startsWith("video/")
-                || MediaType.APPLICATION_OCTET_STREAM_VALUE.equals(contentType))) {
-            throw new UnsupportedMediaTypeException(contentType);
+        String ct = Optional.ofNullable(file.getContentType()).orElse(MediaType.APPLICATION_OCTET_STREAM_VALUE);
+        if (!(ct.startsWith("image/") || ct.startsWith("video/") || MediaType.APPLICATION_OCTET_STREAM_VALUE.equals(ct))) {
+            throw new UnsupportedMediaTypeException(ct);
         }
 
+        String filename = file.getOriginalFilename() != null ? file.getOriginalFilename() : "upload.bin";
         String taskId = form.getOrDefault("taskId", UUID.randomUUID().toString());
+        long size = file.getSize();
 
-        MultipartBodyBuilder mb = new MultipartBodyBuilder();
-        mb.part("file", file.getResource())
-                .filename(file.getOriginalFilename() != null ? file.getOriginalFilename() : "upload.mp4")
-                .contentType(file.getContentType() != null ? MediaType.parseMediaType(file.getContentType())
-                        : MediaType.APPLICATION_OCTET_STREAM);
+        // 기준: 10MB 이하 & image/* 는 메시지로 직접, 그 외는 S3로
+        final long INLINE_LIMIT = 10L * 1024 * 1024;
 
-        passThrough(mb, "loginId", user.getLoginId());
-        passThrough(mb, "taskId", taskId);
-        passThrough(mb, "mode", form.get("mode"));
-        passThrough(mb, "detector", form.get("detector"));
-        passThrough(mb, "use_tta", form.get("use_tta"));
-        passThrough(mb, "use_illum", form.get("use_illum"));
-        passThrough(mb, "min_face", form.get("min_face"));
-        passThrough(mb, "sample_count", form.get("sample_count"));
-        passThrough(mb, "smooth_window", form.get("smooth_window"));
-//        passThrough(mb, "target_fps", form.get("target_fps"));
-//        passThrough(mb, "max_latency_ms", form.get("max_latency_ms"));
-
+        // Task 등록(PENDING)
         activeTaskService.registerTask(user.getLoginId(), taskId);
-        FlaskResponseDTO flaskResult;
+
+        // 메시지 Publish
+        DeepfakeRequestMessage.DeepfakeRequestMessageBuilder builder = DeepfakeRequestMessage.builder()
+                .taskId(taskId)
+                .userId(user.getUserId())
+                .loginId(user.getLoginId())
+                .originalFilename(filename)
+                .contentType(ct)
+                .mode(form.get("mode"))
+                .detector(form.get("detector"))
+                .useTta(form.get("use_tta"))
+                .useIllum(form.get("use_illum"))
+                .minFace(form.get("min_face"))
+                .sampleCount(form.get("sample_count"))
+                .smoothWindow(form.get("smooth_window"));
+
         try {
-            flaskResult = webClient.post()
-                    .uri(flaskServerUrl + "/predict")
-                    .contentType(MediaType.MULTIPART_FORM_DATA)
-                    .body(BodyInserters.fromMultipartData(mb.build()))
-                    .retrieve()
-                    .bodyToMono(FlaskResponseDTO.class)
-                    .block();
-        } catch (org.springframework.web.reactive.function.client.WebClientResponseException e) {
-            // HTTP 응답은 왔지만 4xx/5xx
-            throw new ExternalServiceException("Flask HTTP error: " + e.getRawStatusCode() + " " + e.getResponseBodyAsString());
-        } catch (org.springframework.web.reactive.function.client.WebClientRequestException e) {
-            // 연결 실패/타임아웃 등
-            throw new ExternalServiceException("Flask request failed: " + e.getMessage());
-        }  catch (Exception e) {
-            throw new ExternalServiceException("Flask invocation failed");
-        } finally {
-            activeTaskService.registerTask(user.getLoginId(), taskId);
+            if (ct.startsWith("image/") && size <= INLINE_LIMIT) {
+                // 경로 A: 작은 이미지 → 메시지로 바로
+                builder.fileBytes(file.getBytes());
+            } else {
+                // 경로 B: 큰 이미지/영상 → S3 업로드 후 키만 전달
+                String key = uploadPrefix + "/" + userId + "/" + taskId + "/" + filename;
+                try (InputStream in = file.getInputStream()) {
+                    amazonS3Service.uploadBinary(in, key, ct);
+                }
+                builder.s3Key(key);
+            }
+        } catch (IOException e) {
+            throw new StorageException("Failed to prepare upload", e);
         }
 
+        // Task 등록(PENDING)
+        activeTaskService.registerTask(user.getLoginId(), taskId);
 
-        if (flaskResult == null) {
-            throw new ExternalServiceException("Flask response is null");
-        }
+        // 메시지 발행 (오버로드 모호성 방지: 3-인자 호출)
+        rabbitTemplate.convertAndSend(RabbitConfig.EXCHANGE, RabbitConfig.REQ_ROUTING, builder.build());
 
-        String base64Image = flaskResult.getBase64Url();
-
-        if (base64Image != null && !base64Image.isEmpty()) {
-            flaskResult.setImageUrl(uploadBase64ImageToS3(base64Image, user.getUserId()));
-        }
-
-        DeepfakeDetection entity = mapToEntity(user, flaskResult);
-        List<BulletDTO> stability = assembler.makeStabilityBullets(entity);
-        List<BulletDTO> speed     = assembler.makeSpeedBullets(entity);
-        if (stability == null || speed == null) {
-            throw new DataMappingException("bullet assembling failed");
-        }
-        entity.setStabilityScore(DeepfakeViewAssembler.meanScore(stability));
-        entity.setSpeedScore(DeepfakeViewAssembler.meanScore(speed));
-        deepfakeDetectionRepository.save(entity);
-
-        return DeepfakeDetectionDTO.fromEntity(entity,stability, speed);
+        return new TaskAcceptedDTO(taskId);
     }
+
+
 
     public String uploadBase64ImageToS3(String base64Image, Long userId) {
         userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException(userId));
@@ -138,100 +121,6 @@ public class DeepfakeDetectionService {
             throw new StorageException("failed to upload image to S3", e);
         }
     }
-
-    private static void passThrough(MultipartBodyBuilder mb, String key, String val) {
-        if (val != null) {
-            mb.part(key, val, MediaType.TEXT_PLAIN);
-        }
-    }
-
-    private DeepfakeDetection mapToEntity(User user, FlaskResponseDTO flaskResponseDTO) {
-        if (flaskResponseDTO == null) throw new DataMappingException("flask response is null");
-        if (flaskResponseDTO.getTaskId() == null || flaskResponseDTO.getImageUrl() == null || flaskResponseDTO.getResult() == null) {
-            throw new DataMappingException("required fields missing in flask response");
-        }
-        DeepfakeDetection detection = new DeepfakeDetection();
-        detection.setUser(user);
-        detection.setTaskId(flaskResponseDTO.getTaskId());
-        detection.setFilePath(flaskResponseDTO.getImageUrl());
-        detection.setResult(flaskResponseDTO.getResult());
-
-        // 판정/점수
-        detection.setScoreWeighted(flaskResponseDTO.getScoreWeighted());
-        detection.setThresholdTau(flaskResponseDTO.getThresholdTau());
-        detection.setFrameVoteRatio(flaskResponseDTO.getFrameVoteRatio());
-
-        // 통계
-        detection.setAverageConfidence(flaskResponseDTO.getAverageConfidence());
-        detection.setMedianConfidence(flaskResponseDTO.getMedianConfidence());
-        detection.setMaxConfidence(flaskResponseDTO.getMaxConfidence());
-        detection.setVarianceConfidence(flaskResponseDTO.getVarianceConfidence());
-
-        // 처리량/시간
-        detection.setFramesProcessed(flaskResponseDTO.getFramesProcessed());
-        detection.setProcessingTimeSec(flaskResponseDTO.getProcessingTimeSec());
-
-        // 속도(SLA 에코)
-        if (flaskResponseDTO.getSpeed() != null) {
-            detection.setMsPerSample(flaskResponseDTO.getSpeed().getMsPerSample());
-            detection.setTargetFpsUsed(flaskResponseDTO.getSpeed().getTargetFps());
-            detection.setMaxLatencyMsUsed(flaskResponseDTO.getSpeed().getMaxLatencyMs());
-            detection.setSpeedOk(flaskResponseDTO.getSpeed().getSpeedOk());
-            detection.setFpsProcessed(flaskResponseDTO.getSpeed().getFpsProcessed());
-        }
-
-        // 안정성 원시
-        if (flaskResponseDTO.getStabilityEvidence() != null) {
-            detection.setTemporalDeltaMean(flaskResponseDTO.getStabilityEvidence().getTemporalDeltaMean());
-            detection.setTemporalDeltaStd(flaskResponseDTO.getStabilityEvidence().getTemporalDeltaStd());
-            detection.setTtaMean(flaskResponseDTO.getStabilityEvidence().getTtaMean());
-            detection.setTtaStd(flaskResponseDTO.getStabilityEvidence().getTtaStd());
-        }
-
-        // 실행 환경/프로비넌스
-        if (flaskResponseDTO.getMode() != null) {
-            try {
-                detection.setMode(DeepfakeMode.valueOf(flaskResponseDTO.getMode().toUpperCase()));
-            } catch (IllegalArgumentException ex) {
-                throw new InvalidEnumValueException("mode", flaskResponseDTO.getMode());
-            }
-        }
-        if (flaskResponseDTO.getDetector() != null) {
-            try {
-                detection.setDetector(DeepfakeDetector.valueOf(flaskResponseDTO.getDetector().toUpperCase()));
-            } catch (IllegalArgumentException ex) {
-                throw new InvalidEnumValueException("detector", flaskResponseDTO.getDetector());
-            }
-        }
-        detection.setUseTta(flaskResponseDTO.getUseTta());
-        detection.setUseIllum(flaskResponseDTO.getUseIllum());
-        detection.setMinFace(flaskResponseDTO.getMinFace());
-        detection.setSampleCount(flaskResponseDTO.getSampleCount());
-        detection.setSmoothWindow(flaskResponseDTO.getSmoothWindow());
-
-        // 히트맵
-        if (flaskResponseDTO.getTimeseries() != null && flaskResponseDTO.getTimeseries().getPerFrameConf() != null) {
-            String json = "{\"per_frame_conf\":" + toJsonArray(flaskResponseDTO.getTimeseries().getPerFrameConf())
-                    + ",\"vmin\":" + numOrNull(flaskResponseDTO.getTimeseries().getVmin())
-                    + ",\"vmax\":" + numOrNull(flaskResponseDTO.getTimeseries().getVmax()) + "}";
-            detection.setTimeseriesJson(json);
-        }
-
-        return detection;
-    }
-
-    private static String toJsonArray(List<Float> list) {
-        StringBuilder sb = new StringBuilder("[");
-        for (int i=0;i<list.size();i++){
-            if (i>0) sb.append(',');
-            Float v = list.get(i);
-            sb.append(v==null?"null":String.valueOf(v));
-        }
-        sb.append(']');
-        return sb.toString();
-    }
-
-    private static String numOrNull(Number n){ return n==null?"null":String.valueOf(n); }
 
     public Page<DeepfakeDetectionListDTO> getAllResult(Long userId, Pageable pageable){
         userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException(userId));

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/worker/DeepfakeWorker.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/worker/DeepfakeWorker.java
@@ -1,0 +1,268 @@
+package com.deeptruth.deeptruth.worker;
+
+import com.deeptruth.deeptruth.base.Enum.DeepfakeDetector;
+import com.deeptruth.deeptruth.base.Enum.DeepfakeMode;
+import com.deeptruth.deeptruth.base.dto.websocket.DeepfakeRequestMessage;
+import com.deeptruth.deeptruth.base.dto.deepfake.BulletDTO;
+import com.deeptruth.deeptruth.base.dto.deepfake.DeepfakeDetectionDTO;
+import com.deeptruth.deeptruth.base.dto.deepfake.DeepfakeDetectionListDTO;
+import com.deeptruth.deeptruth.base.dto.deepfake.FlaskResponseDTO;
+import com.deeptruth.deeptruth.base.dto.websocket.TaskEvent;
+import com.deeptruth.deeptruth.base.exception.*;
+import com.deeptruth.deeptruth.config.RabbitConfig;
+import com.deeptruth.deeptruth.entity.DeepfakeDetection;
+import com.deeptruth.deeptruth.entity.User;
+import com.deeptruth.deeptruth.repository.DeepfakeDetectionRepository;
+import com.deeptruth.deeptruth.repository.UserRepository;
+import com.deeptruth.deeptruth.service.ActiveTaskService;
+import com.deeptruth.deeptruth.service.AmazonS3Service;
+import com.deeptruth.deeptruth.service.DeepfakeViewAssembler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.AmqpRejectAndDontRequeueException;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.MultipartBodyBuilder;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DeepfakeWorker {
+
+    private final SimpMessagingTemplate ws;
+    private final DeepfakeDetectionRepository repo;
+    private final UserRepository userRepository;
+    private final DeepfakeViewAssembler assembler;
+    private final WebClient webClient;
+    private final ActiveTaskService activeTaskService;
+    private final DeepfakeDetectionRepository deepfakeDetectionRepository;
+    private final AmazonS3Service amazonS3Service;
+
+
+    @org.springframework.beans.factory.annotation.Value("${flask.deepfakeServer.url}")
+    private String flaskServerUrl;
+
+    @RabbitListener(queues = RabbitConfig.REQ_QUEUE)
+    public void onMessage(DeepfakeRequestMessage msg) {
+        final String taskId = msg.getTaskId();
+        final String loginId = msg.getLoginId();
+
+        try {
+            sendProgress(loginId, taskId, 5);
+
+            final String filename = Optional.ofNullable(msg.getOriginalFilename()).orElse("upload.bin");
+            final String contentType = Optional.ofNullable(msg.getContentType()).orElse(MediaType.APPLICATION_OCTET_STREAM_VALUE);
+
+            // 1) 파일 파트 구성
+            byte[] bodyBytes;
+            if (msg.getFileBytes() != null && msg.getFileBytes().length > 0) {
+                bodyBytes = msg.getFileBytes();
+            } else if (msg.getS3Key() != null) {
+                try (InputStream in = amazonS3Service.openStream(msg.getS3Key())) {
+                    bodyBytes = in.readAllBytes(); // Java 11+
+                }
+            } else {
+                throw new IllegalStateException("No input provided (fileBytes or s3Key missing)");
+            }
+
+            MultipartBodyBuilder mb = new MultipartBodyBuilder();
+            ByteArrayResource res = new ByteArrayResource(bodyBytes) {
+                @Override public String getFilename() { return filename; }
+            };
+            mb.part("file", res)
+                    .filename(filename)
+                    .contentType(MediaType.parseMediaType(contentType));
+
+            // pass-through 옵션
+            pass(mb, "taskId", taskId);
+            pass(mb, "loginId", loginId);
+            pass(mb, "mode", msg.getMode());
+            pass(mb, "detector", msg.getDetector());
+            pass(mb, "use_tta", msg.getUseTta());
+            pass(mb, "use_illum", msg.getUseIllum());
+            pass(mb, "min_face", msg.getMinFace());
+            pass(mb, "sample_count", msg.getSampleCount());
+            pass(mb, "smooth_window", msg.getSmoothWindow());
+
+            sendProgress(loginId, taskId, 10);
+
+            // 2) Flask 호출
+            FlaskResponseDTO flask = webClient.post()
+                    .uri(flaskServerUrl + "/predict")
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
+                    .body(BodyInserters.fromMultipartData(mb.build()))
+                    .retrieve()
+                    .bodyToMono(FlaskResponseDTO.class)
+                    .block();
+
+            if (flask == null) throw new RuntimeException("Flask response is null");
+
+            // 3) 결과 이미지 S3 저장
+            if (flask.getBase64Url() != null && !flask.getBase64Url().isEmpty()) {
+                String uploaded = uploadBase64ImageToS3(flask.getBase64Url(), msg.getUserId());
+                flask.setImageUrl(uploaded);
+            }
+
+            sendProgress(loginId, taskId, 70);
+
+            // 4) DB 저장 + WS 완료
+            User user = userRepository.findById(msg.getUserId())
+                    .orElseThrow(() -> new RuntimeException("User not found: " + msg.getUserId()));
+
+            DeepfakeDetection entity = mapToEntity(user, flask); // 네 기존 메서드 재사용
+            List<BulletDTO> stability = assembler.makeStabilityBullets(entity);
+            List<BulletDTO> speed = assembler.makeSpeedBullets(entity);
+            if (stability == null || speed == null) throw new RuntimeException("bullet assembling failed");
+            entity.setStabilityScore(DeepfakeViewAssembler.meanScore(stability));
+            entity.setSpeedScore(DeepfakeViewAssembler.meanScore(speed));
+            repo.save(entity);
+
+            sendProgress(loginId, taskId, 100);
+
+            ws.convertAndSendToUser(loginId, "/queue/tasks/" + taskId,
+                    TaskEvent.done(taskId, DeepfakeDetectionDTO.fromEntity(entity, stability, speed)));
+
+        } catch (Exception e) {
+            log.error("Deepfake task failed: taskId={}, err={}", taskId, e.getMessage(), e);
+            ws.convertAndSendToUser(loginId, "/queue/tasks/" + taskId, TaskEvent.error(taskId, "AI_PROCESS_FAILED"));
+            throw new AmqpRejectAndDontRequeueException("fail", e);
+        } finally {
+            activeTaskService.registerTask(loginId, taskId);
+        }
+    }
+
+
+    public String uploadBase64ImageToS3(String base64Image, Long userId) {
+        userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException(userId));
+        final byte[] decodedBytes;
+        try {
+            decodedBytes = Base64.getDecoder().decode(base64Image);
+        } catch (IllegalArgumentException e) {
+            throw new ImageDecodingException("invalid base64");
+        }
+
+        try (InputStream inputStream = new ByteArrayInputStream(decodedBytes)) {
+            String key = "deepfake/" + userId + "/" + UUID.randomUUID() + ".jpg";
+            return amazonS3Service.uploadBase64Image(inputStream, key);
+        } catch (Exception e) {
+            throw new StorageException("failed to upload image to S3", e);
+        }
+    }
+    private void pass(MultipartBodyBuilder mb, String k, String v) {
+        if (v != null) mb.part(k, v, MediaType.TEXT_PLAIN);
+    }
+    private void sendProgress(String loginId, String taskId, int p) {
+        ws.convertAndSendToUser(loginId, "/queue/tasks/" + taskId, TaskEvent.progress(taskId, p));
+    }
+
+    private DeepfakeDetection mapToEntity(User user, FlaskResponseDTO dto) {
+        if (dto == null) throw new DataMappingException("flask response is null");
+        if (dto.getTaskId() == null || dto.getImageUrl() == null || dto.getResult() == null) {
+            throw new DataMappingException("required fields missing in flask response");
+        }
+        DeepfakeDetection detection = new DeepfakeDetection();
+        detection.setUser(user);
+        detection.setTaskId(dto.getTaskId());
+        detection.setFilePath(dto.getImageUrl());
+        detection.setResult(dto.getResult());
+
+        // 판정/점수
+        detection.setScoreWeighted(dto.getScoreWeighted());
+        detection.setThresholdTau(dto.getThresholdTau());
+        detection.setFrameVoteRatio(dto.getFrameVoteRatio());
+
+        // 통계
+        detection.setAverageConfidence(dto.getAverageConfidence());
+        detection.setMedianConfidence(dto.getMedianConfidence());
+        detection.setMaxConfidence(dto.getMaxConfidence());
+        detection.setVarianceConfidence(dto.getVarianceConfidence());
+
+        // 처리량/시간
+        detection.setFramesProcessed(dto.getFramesProcessed());
+        detection.setProcessingTimeSec(dto.getProcessingTimeSec());
+
+        // 속도(SLA 에코)
+        if (dto.getSpeed() != null) {
+            detection.setMsPerSample(dto.getSpeed().getMsPerSample());
+            detection.setTargetFpsUsed(dto.getSpeed().getTargetFps());
+            detection.setMaxLatencyMsUsed(dto.getSpeed().getMaxLatencyMs());
+            detection.setSpeedOk(dto.getSpeed().getSpeedOk());
+            detection.setFpsProcessed(dto.getSpeed().getFpsProcessed());
+        }
+
+        // 안정성 원시
+        if (dto.getStabilityEvidence() != null) {
+            detection.setTemporalDeltaMean(dto.getStabilityEvidence().getTemporalDeltaMean());
+            detection.setTemporalDeltaStd(dto.getStabilityEvidence().getTemporalDeltaStd());
+            detection.setTtaMean(dto.getStabilityEvidence().getTtaMean());
+            detection.setTtaStd(dto.getStabilityEvidence().getTtaStd());
+        }
+
+        // 실행 환경/프로비넌스
+        if (dto.getMode() != null) {
+            try {
+                detection.setMode(DeepfakeMode.valueOf(dto.getMode().toUpperCase()));
+            } catch (IllegalArgumentException ex) {
+                throw new InvalidEnumValueException("mode", dto.getMode());
+            }
+        }
+        if (dto.getDetector() != null) {
+            try {
+                detection.setDetector(DeepfakeDetector.valueOf(dto.getDetector().toUpperCase()));
+            } catch (IllegalArgumentException ex) {
+                throw new InvalidEnumValueException("detector", dto.getDetector());
+            }
+        }
+        detection.setUseTta(dto.getUseTta());
+        detection.setUseIllum(dto.getUseIllum());
+        detection.setMinFace(dto.getMinFace());
+        detection.setSampleCount(dto.getSampleCount());
+        detection.setSmoothWindow(dto.getSmoothWindow());
+
+        // 히트맵
+        if (dto.getTimeseries() != null && dto.getTimeseries().getPerFrameConf() != null) {
+            String json = "{\"per_frame_conf\":" + toJsonArray(dto.getTimeseries().getPerFrameConf())
+                    + ",\"vmin\":" + numOrNull(dto.getTimeseries().getVmin())
+                    + ",\"vmax\":" + numOrNull(dto.getTimeseries().getVmax()) + "}";
+            detection.setTimeseriesJson(json);
+        }
+
+        return detection;
+    }
+
+
+    private static String toJsonArray(List<Float> list) {
+        StringBuilder sb = new StringBuilder("[");
+        for (int i=0;i<list.size();i++){
+            if (i>0) sb.append(',');
+            Float v = list.get(i);
+            sb.append(v==null?"null":String.valueOf(v));
+        }
+        sb.append(']');
+        return sb.toString();
+    }
+
+    private static String numOrNull(Number n){ return n==null?"null":String.valueOf(n); }
+
+    public Page<DeepfakeDetectionListDTO> getAllResult(Long userId, Pageable pageable){
+        userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException(userId));
+        if (pageable == null) throw new DataMappingException("pageable is null");
+        return deepfakeDetectionRepository.findByUser_UserId(userId, pageable)
+                .map(DeepfakeDetectionListDTO::fromEntity);
+    }
+
+}

--- a/deeptruth/src/main/java/com/deeptruth/deeptruth/worker/DeepfakeWorker.java
+++ b/deeptruth/src/main/java/com/deeptruth/deeptruth/worker/DeepfakeWorker.java
@@ -62,7 +62,7 @@ public class DeepfakeWorker {
         final String loginId = msg.getLoginId();
 
         try {
-            sendProgress(loginId, taskId, 5);
+            // sendProgress(loginId, taskId, 5);
 
             final String filename = Optional.ofNullable(msg.getOriginalFilename()).orElse("upload.bin");
             final String contentType = Optional.ofNullable(msg.getContentType()).orElse(MediaType.APPLICATION_OCTET_STREAM_VALUE);
@@ -98,7 +98,7 @@ public class DeepfakeWorker {
             pass(mb, "sample_count", msg.getSampleCount());
             pass(mb, "smooth_window", msg.getSmoothWindow());
 
-            sendProgress(loginId, taskId, 10);
+           //  sendProgress(loginId, taskId, 10);
 
             // 2) Flask 호출
             FlaskResponseDTO flask = webClient.post()
@@ -117,13 +117,13 @@ public class DeepfakeWorker {
                 flask.setImageUrl(uploaded);
             }
 
-            sendProgress(loginId, taskId, 70);
+            // sendProgress(loginId, taskId, 70);
 
             // 4) DB 저장 + WS 완료
             User user = userRepository.findById(msg.getUserId())
                     .orElseThrow(() -> new RuntimeException("User not found: " + msg.getUserId()));
 
-            DeepfakeDetection entity = mapToEntity(user, flask); // 네 기존 메서드 재사용
+            DeepfakeDetection entity = mapToEntity(user, flask);
             List<BulletDTO> stability = assembler.makeStabilityBullets(entity);
             List<BulletDTO> speed = assembler.makeSpeedBullets(entity);
             if (stability == null || speed == null) throw new RuntimeException("bullet assembling failed");
@@ -131,7 +131,7 @@ public class DeepfakeWorker {
             entity.setSpeedScore(DeepfakeViewAssembler.meanScore(speed));
             repo.save(entity);
 
-            sendProgress(loginId, taskId, 100);
+            // sendProgress(loginId, taskId, 100);
 
             ws.convertAndSendToUser(loginId, "/queue/tasks/" + taskId,
                     TaskEvent.done(taskId, DeepfakeDetectionDTO.fromEntity(entity, stability, speed)));


### PR DESCRIPTION
## 📝 Summary
동기 HTTP 호출로 Flask 추론을 기다리던 구조를 **RabbitMQ 비동기 파이프라인**으로 전환했습니다.
API 서버는 업로드를 **수신만** 하고 즉시 `202 Accepted` + `taskId`를 반환,
워커가 Flask 호출/결과 처리/DB 저장을 수행한 뒤 **WebSocket(/user/queue/...)** 으로 진행률/완료를 사용자별로 푸시합니다.
대용량 파일은 **S3 Key**, 소용량 이미지는 **byte[] 인라인**으로 큐를 통해 전달합니다.

## 💻 Describe your changes
## 1) 변경 사항 (주요 포인트)

* **메시징**
  * `RabbitConfig` 추가: `deeptruth.direct`(DirectExchange), `deepfake.request.q`, DLX/DLQ 구성, TTL(10분).
  * Producer: `rabbitTemplate.convertAndSend(EXCHANGE, ROUTING, message)`로 요청 메시지 발행.
  * Consumer(워커): `@RabbitListener` 로 메시지 소비 → Flask `/predict` 호출 → 결과 처리.
* **DTO/전송 정책**
  * `DeepfakeRequestMessage` 신설
    * `byte[] fileBytes`(작은 이미지 ≤10MB) **또는** `String s3Key`(대용량/영상)
    * `originalFilename`, `contentType`, 옵션 필드(mode, detector 등)
  * 멀티파트 전송에서 **InputStreamResource 금지** → `ByteArrayResource + byte[]`로 변경(읽기 재시도 안전)
* **서비스 흐름 변경**
  * `POST /api/deepfake` → 로컬 저장 제거
    * 작은 이미지: 메시지에 **byte[]** 로 인라인
    * 큰 파일/영상: **S3 업로드 → s3Key**만 메시지에 포함
  * 즉시 `202 Accepted` + `taskId` 반환 (기존 동기 결과 반환과 **호환되지 않음**)
* **워커(DeepfakeWorker)**
  * 메시지 수신 → (fileBytes 또는 s3Key로) Flask 멀티파트 요청
  * Flask 응답의 `base64Url` 이미지는 **S3 업로드** 후 URL로 치환
  * `mapToEntity + assembler` 로 DB 저장
  * WebSocket 푸시: `convertAndSendToUser(loginId, "/queue/tasks/{taskId}", TaskEvent)`
    * ✅ 개인 전송이므로 **/topic 아님, /queue 사용**
* **WebSocket**
  * `setUserDestinationPrefix("/user")` 전제
  * 프론트 구독 경로: `/user/queue/tasks/{taskId}`
  * Flask 측 외부 콜백(controller)도 `convertAndSendToUser(..., "/queue/progress/{taskId}", ...)`로 수정
* **S3 유틸**
  * `AmazonS3Service.uploadBinary(InputStream, key, contentType)` 추가
  * `openStream(key)`로 읽기 지원
* **에러/이슈 해결 기록 반영**
  * `InputStreamResource` 다중 읽기 예외 → **ByteArrayResource + byte[]** 로 해결
  * Flask `Invalid chunk header` → **고정 길이 본문(배열 전송)** + **Waitress** 권장
  * `convertAndSend` 오버로드 모호성 → **3-인자** 호출로 고정
  * `ConnectionFactory` 임포트 충돌 → Spring AMQP 타입으로 정정
  * WebSocket 개인 메시지에 **/topic 사용 금지** → `/queue` 로 통일

## 2) 설정/환경

* **build.gradle**
  * `spring-boot-starter-amqp`, `spring-boot-starter-webflux`, `aws-java-sdk-s3`


* **로컬 RabbitMQ 실행(참고)**
  ```bash
  docker run -d --name rabbit \
    -p 5672:5672 -p 15672:15672 \
    -e RABBITMQ_DEFAULT_USER=guest \
    -e RABBITMQ_DEFAULT_PASS=guest \
    rabbitmq:3.13-management
  ```

## 3) 동작 시나리오

1. 클라이언트가 `POST /api/deepfake`로 파일 업로드
   → 서버는 파일 정책에 따라 byte[] 인라인 or S3 업로드 후 `s3Key`만 포함한 메시지 발행
   → 즉시 `202 Accepted`와 `taskId` 반환
2. 워커가 큐를 소비
   → Flask `/predict` 호출
   → 응답의 `base64Url` 이미지를 S3 업로드(이미지 URL로 치환)
   → DB 저장
   → `/user/queue/tasks/{taskId}`로 `PROGRESS/DONE/ERROR` 이벤트 푸시

## 4) 리스크/호환성

* **Breaking change**: `POST /api/deepfake`가 더 이상 동기 결과를 반환하지 않음 → `202 + taskId`로 변경
* WebSocket 개인 푸시는 `/user/queue/**` 구독을 전제로 함 (프론트 수정 필요)
* 대용량 파일은 반드시 S3 업로드 경로 사용 권장(메모리 사용량 이슈 방지)


## #️⃣ Issue number and link
#40 #58 

## 💬 Message to the Reviewer

# 프론트에게 (중요 변경사항)

* **결과 수신 방식 변경**

  * 업로드 응답: `202 Accepted` + `taskId`
  * 진행률/완료 구독: **`/user/queue/tasks/{taskId}`**
* 예시:

  ```js
  // 업로드 후
  const { taskId } = await postUpload();
  // WS 연결 후
  stomp.subscribe(`/user/queue/tasks/${taskId}`, (frame) => {
    const ev = JSON.parse(frame.body); // {type: PROGRESS|DONE|ERROR, ...}
  });
  ```
* 공지/브로드캐스트가 필요한 경우에만 `/topic/**` 사용, 개인 메시지는 항상 `/user/queue/**` 구독


